### PR TITLE
Optimize ActiveStorage authorization performance

### DIFF
--- a/app/models/concerns/active_storage_authorization.rb
+++ b/app/models/concerns/active_storage_authorization.rb
@@ -54,7 +54,7 @@ module ActiveStorageAuthorization
   private
 
   def set_download_blob
-    @blob ||= ActiveStorage::Blob.where(key: decode_verified_key().try(:dig, :key)).first
+    @blob ||= ActiveStorage::Blob.includes(:attachments, :active_storage_extensions).where(key: decode_verified_key().try(:dig, :key)).first
   end
 
   # Authorize the current blob and prevent it from being served if unauthorized

--- a/app/models/concerns/active_storage_authorization.rb
+++ b/app/models/concerns/active_storage_authorization.rb
@@ -14,12 +14,12 @@
 module ActiveStorageAuthorization
   extend ActiveSupport::Concern
 
-  AUTHORIZED_EFFECTIVE_DOWNLOADS = [
-    'Effective::CarouselItem', 
-    'Effective::PageBanner', 
-    'Effective::PageSection', 
+  AUTHORIZED_EFFECTIVE_DOWNLOADS = Set.new([
+    'Effective::CarouselItem',
+    'Effective::PageBanner',
+    'Effective::PageSection',
     'Effective::Permalink'
-  ]
+  ]).freeze
 
   included do
     rescue_from(Effective::UnauthorizedStorageException, with: :unauthorized_active_storage_request)
@@ -73,11 +73,11 @@ module ActiveStorageAuthorization
     # If the blob is a known good effective class fast path it
     return true if @blob.attachments.any? { |attachment| authorized_effective_download?(attachment) }
 
+    # If the blob has been marked public, permit the download (in-memory check, no queries)
+    return true if @blob.permission_public?
+
     # If we are authorized on any attached record, permit the download
     return true if @blob.attachments.any? { |attachment| authorized_attachment_download?(attachment) }
-
-    # If the blob has been given permission using Mark Public
-    return true if authorized?(@blob)
 
     # Otherwise raise a 404 Not Found and block the download
     head(:not_found)

--- a/lib/effective_storage/engine.rb
+++ b/lib/effective_storage/engine.rb
@@ -30,10 +30,22 @@ module EffectiveStorage
 
           ActiveStorage::Blobs::RedirectController.class_eval do
             before_action :authorize_active_storage_redirect!, only: [:show]
+
+            private
+
+            def blob_scope
+              ActiveStorage::Blob.includes(:attachments, :active_storage_extensions)
+            end
           end
 
           ActiveStorage::Representations::RedirectController.class_eval do
             before_action :authorize_active_storage_redirect!, only: [:show]
+
+            private
+
+            def blob_scope
+              ActiveStorage::Blob.scope_for_strict_loading.includes(:attachments, :active_storage_extensions)
+            end
           end
         end
       end


### PR DESCRIPTION
## Summary
- **Eager-load associations**: `set_blob` now uses `includes(:attachments, :active_storage_extensions)` to eliminate N+1 queries during authorization
- **Early public blob check**: Move `permission_public?` before the CanCan-heavy `authorized_attachment_download?` block, skipping up to 5 `instance_exec` calls for public blobs
- **Set lookup**: Convert `AUTHORIZED_EFFECTIVE_DOWNLOADS` from Array to Set for O(1) `include?`

## Test plan
- [ ] Access a blob marked as "public" in admin — confirm no CanCan-related queries in the log
- [ ] Access a private blob as a logged-in user — confirm normal authorization still works
- [ ] Access a blob attached to an `Effective::CarouselItem` — confirm the fast-path still works
- [ ] Access a blob as admin — confirm admin catch-all still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)